### PR TITLE
Fix for unknown application icon

### DIFF
--- a/data/io.github.mimbrero.WhatsAppDesktop.desktop
+++ b/data/io.github.mimbrero.WhatsAppDesktop.desktop
@@ -6,3 +6,4 @@ Type=Application
 Icon=io.github.mimbrero.WhatsAppDesktop
 Comment=An unofficial WhatsApp client for Linux, built with Electron.
 Categories=Utility;Network;Chat;InstantMessaging;
+StartupWMClass=whatsapp-desktop-linux


### PR DESCRIPTION
Adds the `StartupWMClass` property in the desktop launcher, so that the correct application icon of the system's icon theme will be used for the opened window (e.g. in the Dock).

The value was obtained by running `xprop` and clicking on the application window.