### PR TITLE
Fixed tray manager never showing "Minimize to tray"

### DIFF
--- a/src/tray-manager.ts
+++ b/src/tray-manager.ts
@@ -39,7 +39,7 @@ export default class TrayManager {
     private updateMenu() {
         const menu = Menu.buildFromTemplate([
             {
-                label: this.window.isFocused() ? "Minimize to tray" : "Show WhatsApp",
+                label: this.window.isVisible() ? "Minimize to tray" : "Show WhatsApp",
                 click: () => this.onClickFirstItem()
             },
             {
@@ -66,11 +66,10 @@ export default class TrayManager {
     }
 
     private onClickFirstItem() {
-        if (this.window.isFocused()) {
+        if (this.window.isVisible()) {
             this.window.hide();
         } else {
             this.window.show();
-            this.window.focus();
         }
 
         this.updateMenu();


### PR DESCRIPTION
After clicking on the tray menu, the window would lose focus so window.isFocused always returned false

Also show() already focus the window, so calling focus() is unnecessary 